### PR TITLE
Point to the signed .xpi in the installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This addon provides some tools to assist developers with remote settings.
 
 # Install
 
-- Open ``about:debugging``
-- Load temporary addon and pick the .zip file from the [releases page](https://github.com/mozilla/remote-settings-devtools/releases)
+- Pick the .xpi file from the [releases page](https://github.com/mozilla/remote-settings-devtools/releases).
+- When asked for comnfirmation, select "Continue to installation".
 
 > Note: it is highly recommended to use a temporary or development user profile
 


### PR DESCRIPTION
The installation instructions seem to be out of date, so I updated them with my best guess of how to do it now.